### PR TITLE
docs: add installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,17 @@ The app will be available at the URL printed in your terminal (by default http:/
 
 ### Available scripts
 
-| Command             | Description                                      |
-| ------------------- | ------------------------------------------------ |
-| `yarn dev`          | Start the Vite development server                |
-| `yarn build`        | Type-check and build for production              |
-| `yarn preview`      | Preview the production build locally             |
-| `yarn test`         | Run the test suite with Vitest                   |
-| `yarn lint`         | Lint the codebase with ESLint                    |
-| `yarn lint:fix`     | Lint and automatically fix issues                |
-| `yarn format`       | Format the codebase with Prettier                |
-| `yarn format:check` | Check formatting without writing changes         |
-| `yarn typecheck`    | Run the TypeScript type checker                  |
+| Command             | Description                              |
+| ------------------- | ---------------------------------------- |
+| `yarn dev`          | Start the Vite development server        |
+| `yarn build`        | Type-check and build for production      |
+| `yarn preview`      | Preview the production build locally     |
+| `yarn test`         | Run the test suite with Vitest           |
+| `yarn lint`         | Lint the codebase with ESLint            |
+| `yarn lint:fix`     | Lint and automatically fix issues        |
+| `yarn format`       | Format the codebase with Prettier        |
+| `yarn format:check` | Check formatting without writing changes |
+| `yarn typecheck`    | Run the TypeScript type checker          |
 
 ## Where?
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,53 @@ In order to create clean and consistent code, I used the `Eslint` linter as well
 
 All my pull requests are checked by running the linter, formatter, type checking and tests via Github Actions. 🛡️
 
+## Getting started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) `24.x`
+- [Yarn](https://yarnpkg.com/) `4.x` (this project uses Yarn `4.15.0`, managed via Corepack)
+
+If Yarn is not already enabled, run:
+
+```bash
+corepack enable
+```
+
+### Installation
+
+Clone the repository and install the dependencies:
+
+```bash
+git clone https://github.com/emmaGblt/cv.git
+cd cv
+yarn install
+```
+
+### Running locally
+
+Start the development server:
+
+```bash
+yarn dev
+```
+
+The app will be available at the URL printed in your terminal (by default http://localhost:5173).
+
+### Available scripts
+
+| Command             | Description                                      |
+| ------------------- | ------------------------------------------------ |
+| `yarn dev`          | Start the Vite development server                |
+| `yarn build`        | Type-check and build for production              |
+| `yarn preview`      | Preview the production build locally             |
+| `yarn test`         | Run the test suite with Vitest                   |
+| `yarn lint`         | Lint the codebase with ESLint                    |
+| `yarn lint:fix`     | Lint and automatically fix issues                |
+| `yarn format`       | Format the codebase with Prettier                |
+| `yarn format:check` | Check formatting without writing changes         |
+| `yarn typecheck`    | Run the TypeScript type checker                  |
+
 ## Where?
 
 You can visit the site here: https://emma-guilbault.netlify.app/


### PR DESCRIPTION
## What

Adds a **Getting started** section to the README with installation and local-development instructions.

## Details

- **Prerequisites** — Node.js `24.x` and Yarn `4.x` (Corepack), matching the `engines` and `packageManager` fields in `package.json`
- **Installation** — clone + `yarn install`
- **Running locally** — `yarn dev` with the default Vite port
- **Available scripts** — a table documenting every script defined in `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)